### PR TITLE
ER図追加

### DIFF
--- a/app/Console/Commands/LineRichMenuSetup.php
+++ b/app/Console/Commands/LineRichMenuSetup.php
@@ -10,10 +10,12 @@ use LINE\Clients\MessagingApi\Api\MessagingApiApi;
 use LINE\Clients\MessagingApi\Api\MessagingApiBlobApi;
 use LINE\Clients\MessagingApi\Model\CreateRichMenuAliasRequest;
 use LINE\Clients\MessagingApi\Model\RichMenuRequest;
+use App\Models\Shop;
 
 class LineRichMenuSetup extends Command
 {
     protected $signature = 'line:richmenu:setup
+        {--shop= : Shop ID to setup richmenu}
         {--normalJson=storage/app/line/richmenus/normal.json}
         {--vipJson=storage/app/line/richmenus/vip.json}
         {--normalImg=public/line/richmenu-normal.png}
@@ -22,66 +24,77 @@ class LineRichMenuSetup extends Command
     protected $description = 'Create rich menus (NORMAL/VIP), upload images, set aliases, set default';
 
     public function handle()
-    {
-        $accessToken = config('services.line.channel_access_token');
-        if (!$accessToken) {
-            $this->error('services.line.channel_access_token が未設定です。');
-            return Command::FAILURE;
-        }
-
-        $config = Configuration::getDefaultConfiguration()->setAccessToken($accessToken);
-        $client = new Client();
-
-        // API クライアント
-        $api  = new MessagingApiApi($client, $config);       // JSON系
-        $blob = new MessagingApiBlobApi($client, $config);   // 画像などバイナリ系
-
-        // -------- NORMAL --------
-        $normal = new RichMenuRequest(json_decode(file_get_contents(base_path($this->option('normalJson'))), true));
-        $normalId = $api->createRichMenu($normal)->getRichMenuId();
-
-        $normalImgPath = base_path($this->option('normalImg'));
-        $normalMime = @mime_content_type($normalImgPath) ?: 'image/png';
-        $blob->setRichMenuImage(
-            $normalId,
-            new \SplFileObject($normalImgPath),
-            null,        // hostIndex
-            [],          // variables
-            $normalMime  // Content-Type (image/png or image/jpeg)
-        );
-
-        $api->updateRichMenuAlias('normal', new CreateRichMenuAliasRequest([
-            'richMenuAliasId' => 'normal',
-            'richMenuId'      => $normalId,
-        ]));
-
-
-        // -------- VIP --------
-        $vip = new RichMenuRequest(json_decode(file_get_contents(base_path($this->option('vipJson'))), true));
-        $vipId = $api->createRichMenu($vip)->getRichMenuId();
-
-        $vipImgPath = base_path($this->option('vipImg'));
-        $vipMime = @mime_content_type($vipImgPath) ?: 'image/png';
-        $blob->setRichMenuImage(
-            $vipId,                      // ← バグ防止：vipId を使う
-            new \SplFileObject($vipImgPath),
-            null,
-            [],
-            $vipMime
-        );
-
-        $api->updateRichMenuAlias('vip', new CreateRichMenuAliasRequest([
-            'richMenuAliasId' => 'vip',
-            'richMenuId'      => $vipId,
-        ]));
-
-
-        // デフォルトは NORMAL
-        $api->setDefaultRichMenu($normalId);
-
-        $this->info("NORMAL created: $normalId (alias: normal)");
-        $this->info("VIP created   : $vipId (alias: vip)");
-
-        return Command::SUCCESS;
+{
+    $shopId = $this->option('shop');
+    if (!$shopId) {
+        $this->error('--shop オプションで店舗IDを指定してください');
+        return Command::FAILURE;
     }
+
+    $shop = Shop::find($shopId);
+    if (!$shop) {
+        $this->error("Shop {$shopId} が見つかりません");
+        return Command::FAILURE;
+    }
+
+    $accessToken = $shop->line_access_token;
+    if (!$accessToken) {
+        $this->error("Shop {$shopId} の line_access_token が未設定です");
+        return Command::FAILURE;
+    }
+
+    $config = Configuration::getDefaultConfiguration()->setAccessToken($accessToken);
+    $client = new Client();
+
+    $api  = new MessagingApiApi($client, $config);
+    $blob = new MessagingApiBlobApi($client, $config);
+
+    // -------- NORMAL --------
+    $normal = new RichMenuRequest(json_decode(file_get_contents(base_path($this->option('normalJson'))), true));
+    $normalId = $api->createRichMenu($normal)->getRichMenuId();
+
+    $normalImgPath = base_path($this->option('normalImg'));
+    $normalMime = @mime_content_type($normalImgPath) ?: 'image/png';
+    $blob->setRichMenuImage(
+        $normalId,
+        new \SplFileObject($normalImgPath),
+        null,
+        [],
+        $normalMime
+    );
+
+    $api->createRichMenuAlias(new CreateRichMenuAliasRequest([
+        'richMenuAliasId' => 'normal',
+        'richMenuId'      => $normalId,
+    ]));
+
+    // -------- VIP --------
+    $vip = new RichMenuRequest(json_decode(file_get_contents(base_path($this->option('vipJson'))), true));
+    $vipId = $api->createRichMenu($vip)->getRichMenuId();
+
+    $vipImgPath = base_path($this->option('vipImg'));
+    $vipMime = @mime_content_type($vipImgPath) ?: 'image/png';
+    $blob->setRichMenuImage(
+        $vipId,
+        new \SplFileObject($vipImgPath),
+        null,
+        [],
+        $vipMime
+    );
+
+    $api->createRichMenuAlias(new CreateRichMenuAliasRequest([
+        'richMenuAliasId' => 'vip',
+        'richMenuId'      => $vipId,
+    ]));
+
+    // デフォルトを NORMAL に設定
+    $api->setDefaultRichMenu($normalId);
+
+    $this->info("Shop {$shopId} ({$shop->name}) にリッチメニューを設定しました");
+    $this->info("NORMAL created: $normalId (alias: normal)");
+    $this->info("VIP created   : $vipId (alias: vip)");
+
+    return Command::SUCCESS;
+}
+
 }


### PR DESCRIPTION
ER図のレビューのほど、よろしくお願いします。

### 本サービスの概要（700文字以内）
本サービスは、床屋・美容室向けの予約管理システムです。ユーザーはLINEミニアプリを通じて直感的に予約ができ、店舗側は管理画面から予約状況や顧客メモを簡単に確認・編集できます。予約は「メニュー選択 → 日時選択 → 確認 → 完了」というシンプルなフローを採用し、キャンセルや変更もLINE通知から操作可能です。カレンダーは所要時間や定休日・休憩時間に応じて自動的に予約可否を反映し、管理者は手動で「×」「tel」「◎」などの記号を設定できます。顧客メモにはテキストや画像を添付でき、履歴として参照可能です。店舗ごとに独自の予約URLを発行でき、管理者はログイン後に店舗情報（営業時間・定休日・休憩時間など）を編集できます。低コストで直感的なUIを提供し、現場での電話対応に近い感覚で運用できる点が特徴です。

---

### MVPで実装する予定の機能
- [x] 予約機能（メニュー選択 → 日時選択 → 確認 → 完了フロー）
- [x] 予約完了画面表示
- [x] 予約キャンセル機能（LINE通知からキャンセル可能）
- [x] 予約変更機能（確認画面・管理画面から）
- [x] カレンダー表示機能（×・tel・◎などの記号を反映）
- [x] カレンダー手動操作機能（管理者による記号設定、ドラッグ&ドロップで変更）
- [x] 管理者用予約一覧表示機能（本日／翌日以降）
- [x] 管理者による予約の手動追加
- [x] 顧客メモ機能（テキスト・画像添付・履歴表示）
- [x] 顧客検索機能（電話帳風セレクトボックスから選択）
- [x] LINE通知機能（予約完了／キャンセル時に顧客・管理者へ通知）
- [x] LINEリッチメニュー連携（予約確認・予約フォーム・電話発信・メニュー閉じる）
- [x] 店舗別予約URL（public_tokenによる識別）
- [x] 管理者ログイン機能（Laravel Breeze, guard: admin）
- [x] パスワード初期発行・変更機能（初回ログイン時変更必須）
- [x] 店舗情報管理機能（営業時間・定休日・休憩時間設定）

---

### ER図
<img width="914" height="837" alt="スクリーンショット 2025-10-03 17 25 08" src="https://github.com/user-attachments/assets/c10f2150-775f-4af9-b54c-2dc57ca92e19" />

---

### ER図の注意点
- [x] プルリクエストに最新のER図のスクリーンショットを画像が表示される形で掲載できているか？
- [x] テーブル名は複数形になっているか？（※`calender_marks`は`calendar_marks`に修正推奨）
- [x] カラムの型は記載されているか？
- [x] 外部キーは適切に設けられているか？
- [x] リレーションは適切に描かれているか？多対多の関係は存在しないか？
- [x] STIは使用しないER図になっているか？
- [x] Postsテーブルにpost_nameのように"テーブル名+カラム名"を付けていないか？
